### PR TITLE
Make application compatible for OTP releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/_build
 /ebin
 /deps
 erl_crash.dump

--- a/mix.exs
+++ b/mix.exs
@@ -2,23 +2,19 @@ defmodule Reagent.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :reagent,
-      version: "0.0.1",
-      elixir: "~> 0.12.3",
-      deps: deps ]
+    [ app:     :reagent,
+      version: "0.0.3",
+      elixir:  "~> 0.12.5",
+      deps:    deps ]
   end
 
-  # Configuration for the OTP application
   def application do
-    [ applications: [:socket, :derp] ]
+    [ applications: [:datastructures, :exts, :socket] ]
   end
 
-  # Returns the list of dependencies in the format:
-  # { :foobar, "~> 0.1", git: "https://github.com/elixir-lang/foobar.git" }
   defp deps do
-    [ { :socket, github: "meh/elixir-socket" },
+    [ { :socket,         github: "meh/elixir-socket" },
       { :datastructures, github: "meh/elixir-datastructures" },
-      { :exts, github: "meh/exts" },
-      { :derp, github: "meh/derp" } ]
+      { :exts,           github: "meh/exts" } ]
   end
 end


### PR DESCRIPTION
I removed `derp` because it's an optional dependency (I use exlager/lager which also hooks into the error_handler), also it caused issues while a relup phase because it's not an OTP compatible application.

---

The addition of `datastructures` to the applications list is needed for [exrm](https://github.com/bitwalker/exrm) (resolving dependencies for release bundling).

---

PRs for the dependencies of `reagent` address the same issues.
