### PR TITLE
Add exts dependency for release builds with exrm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Reagent.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [ applications: [:socket] ]
+    [ applications: [:exts, :socket] ]
   end
 
   defp deps do


### PR DESCRIPTION
Due to the fact that `reagent` uses `exts` as a dependency it would be nice to add it to the applications list, too.
This requirement is currently necessary for release builds made with `exrm`.

As long as `exrm` (resp. the underlying `relx` tool) doesn't find another way to fetch dependencies for packaging I guess we can live with this change. (Explained at bitwalker/exrm#2.)

Shortly in my own words:
_I always forget to check for nested dependencies. :-/_
