### PR TITLE
Fix truncated error messages

### DIFF
--- a/lib/reagent/listener.ex
+++ b/lib/reagent/listener.ex
@@ -162,7 +162,7 @@ defmodule Reagent.Listener do
   @doc false
   def handle_cast({ :acceptors, number }, self) when number > 0 do
     pids = Enum.map(1 .. number, fn _ ->
-      Kernel.spawn_link __MODULE__, :acceptor, [self]
+      { :ok, pid } = Task.start_link __MODULE__, :acceptor, [self]; pid
     end) |> Enum.into HashSet.new
 
     { :noreply, %L{self | acceptors: Set.union(self.acceptors, pids)} }


### PR DESCRIPTION
Errors used to get truncated like this:

```
22:27:48.033 [error] Error in process <0.244.0> with exit value: {#{'__exception__'=>true,'__struct__'=>'Elixir.KeyError',key=>conn,term=>#{'__struct__'=>'Elixir.Reagent.Connection',id=>#Ref<0.0.0.1299>,listener=>#{'__struct__'=>'Elixir.Reagent.Listener',acceptors=>#'__struct__'=>'Elixir.HashSet',root=>{[],[],[],[],[],[],[],[]},...
```

This seems to solve the problem by using Task, as suggested by `fishcakez_` and `ericmj` on `#elixir-lang`.
