### PR TITLE
default start implementation return value 

### DIFF
--- a/lib/reagent/behaviour.ex
+++ b/lib/reagent/behaviour.ex
@@ -44,7 +44,7 @@ defmodule Reagent.Behaviour do
       defoverridable accept: 1
 
       def start(conn) do
-        :ok
+        {:ok, self()}
       end
 
       defoverridable start: 1


### PR DESCRIPTION
Tiny thing.

My dialyzer mentioned it, callback and spec for the start function say it returns `{:ok, pid}` but the default implementation only returns `:ok` . I'm not really sure if returning self is fine, but that's just an example fix. Thanks for the great lib.